### PR TITLE
Added index=False flag to to to_csv method.

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,7 +25,5 @@ longformat = pd.melt(df, id_vars = ['CONCELHO','LAT','LONG'],
 
 # Optional - Write to CSV the resulting format 
 
-longformat.to_csv('longformat_csv.csv')
-
-
+longformat.to_csv('longformat_csv.csv', index=False)
 	


### PR DESCRIPTION
Using the setting "index=False" one avoids to write the index into the target output file.
This is useful to when "index" stores no relevant info.